### PR TITLE
Some changes to eId generation. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nkyimu",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nkyimu",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A library written in TypeScript that allows creating self validating AkomaNtoso documents",
   "author": "Libryo Ltd",
   "main": "build/src/index.js",

--- a/src/Abstracts/AbstractNode.ts
+++ b/src/Abstracts/AbstractNode.ts
@@ -774,7 +774,8 @@ export abstract class AbstractNode implements HasChildrenMap {
 
     return content
       .replace(nodeRegx, '')
-      .replace(/[.()-]/gi, '')
+      .replace(/[.]/gi, '_')
+      .replace(/[\W]/gi, '')
       .trim()
       .replace(/\s/g, '_');
   }


### PR DESCRIPTION
When numbers like “1.3.” exist, then replacing the “.” with an empty string could cause duplicates. Also just replace all non-word characters.