### PR TITLE
Add a `seq` prefix to eId generation when it’s a number generated by …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nkyimu",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A library written in TypeScript that allows creating self validating AkomaNtoso documents",
   "author": "Libryo Ltd",
   "main": "build/src/index.js",

--- a/src/Abstracts/AbstractNode.ts
+++ b/src/Abstracts/AbstractNode.ts
@@ -748,7 +748,7 @@ export abstract class AbstractNode implements HasChildrenMap {
 
     nodeCount[node.getNodeName()] += 1;
 
-    return `${nodePrefix}${nodeCount[node.getNodeName()]}`;
+    return `${nodePrefix}seq${nodeCount[node.getNodeName()]}`;
   }
 
   private getNodeNumberContent(node: AbstractNode) {


### PR DESCRIPTION
…a sequence