### PR TITLE
Fixes the "Node is not allowed as child" in tables

### DIFF
--- a/src/Engine/Generator.ts
+++ b/src/Engine/Generator.ts
@@ -20,6 +20,7 @@ export class Generator {
     const parser = new DOMParser();
     const sanitised = source
       .replace(/>\n(\s)*</g, '><')
+      .replace(/(<\/?(?!span).*?>)\s+(<\/?(?!span).*?>)/gim, '$1$2')
       .replace(/\n/g, ' ')
       .replace(/\s+/g, ' ')
       .trim();


### PR DESCRIPTION
Clears white-space between tags, except spans to prevent clearing out legit white-space.